### PR TITLE
Fixed error with timing of AUTH request to Redis.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -67,28 +67,21 @@ Subscribe.prototype._initClient = function() {
   this.setMaxListeners(0);
   this.client = require('redis').createClient(this.port, this.host, this.clientOptions);
 
+  if(this.password) {
+    this.client.auth(this.password);
+  }
+
   this.client.on('error', this.onError.bind(this));
 
   var self = this;
   this.client.on('ready', function() {
     debug('redis client ready');
 
-    if (self.password) {
-      self.client.auth(self.password, function() {
-          if(self.patternSubscribe) {
-            self._psubscribe();
-          } else {
-            self._subscribe();
-          }
-      });
+    if(self.patternSubscribe) {
+      self._psubscribe();
     } else {
-        if(self.patternSubscribe) {
-          self._psubscribe();
-        } else {
-          self._subscribe();
-        }
+      self._subscribe();
     }
-
   });
 };
 


### PR DESCRIPTION
Hi,

I made a small tweak to the order in which the Redis connection is made. Currently, if a password is supplied, the AUTH command is sent after the ready check, which doesn't work, the check fails. I put the AUTH command immediately after the connection, and it seems to have fixed the issue.

Thanks!
Jim
